### PR TITLE
Only notify that a texture was cleared if the actual texture was allocat...

### DIFF
--- a/src/ofxLoaderBatch.cpp
+++ b/src/ofxLoaderBatch.cpp
@@ -223,8 +223,8 @@ void ofxLoaderBatch::clearTexture(string _textureId){
     drawable[textures[_textureId]] = false;
     if(textures[_textureId]->isAllocated()){
         textures[_textureId]->clear();
+        ofLogNotice("Batch '"+getId()+"'",("Texture '"+_textureId + "' ('"+textureFilenames[_textureId]+"') cleared"));
     }
-    ofLogNotice("Batch '"+getId()+"'",("Texture '"+_textureId + "' ('"+textureFilenames[_textureId]+"') cleared"));
 }
 
 ofxLoaderBatch::~ofxLoaderBatch(){


### PR DESCRIPTION
...ed, and actually cleared. If it wasn't, simply sets the revelant map values.
